### PR TITLE
Add proxy for cbeam rpc

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,7 @@ const path = require('path');
 const routePictures = require('./route/pictures');
 const route35c3 = require('./route/35c3');
 const routeCalendar = require('./route/calendar');
+const routeCBeamRPC = require('./route/cbeamRpc');
 
 const app = new Koa();
 const router = new Router();
@@ -15,6 +16,7 @@ const router = new Router();
 route35c3(router);
 routePictures(router);
 routeCalendar(router);
+routeCBeamRPC(router);
 
 app
   .use(Cors())

--- a/server/route/cbeamRpc.js
+++ b/server/route/cbeamRpc.js
@@ -1,0 +1,19 @@
+require('isomorphic-fetch');
+
+module.exports = (router) => {
+  router.get('/rpc/:method', async (ctx) => {
+    const res = await fetch('http://c-beam.cbrp3.c-base.org:4254/rpc/', {
+      credentials: 'omit',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: `{"jsonrpc":"2.0","id":1550009052773,"method":"${ctx.params.method}","params":""}`,
+      method: 'POST',
+      mode: 'cors',
+    });
+    // const res = await fetch('http://c-beam.cbrp3.c-base.org:4254/rpc/;, {"credentials":"omit","headers":{"content-type":"application/json"},"referrerPolicy":"no-referrer-when-downgrade","body":`{\"jsonrpc\":\"2.0\",\"id\":1550009052773,\"method\":\"${ctx.params.method}\",\"params\":\"\"}`,"method":"POST","mode":"cors"});
+    ctx.assert((res.status === 200), res.status);
+    const body = await res.json();
+    ctx.body = body;
+  });
+};

--- a/server/route/cbeamRpc.js
+++ b/server/route/cbeamRpc.js
@@ -11,7 +11,6 @@ module.exports = (router) => {
       method: 'POST',
       mode: 'cors',
     });
-    // const res = await fetch('http://c-beam.cbrp3.c-base.org:4254/rpc/;, {"credentials":"omit","headers":{"content-type":"application/json"},"referrerPolicy":"no-referrer-when-downgrade","body":`{\"jsonrpc\":\"2.0\",\"id\":1550009052773,\"method\":\"${ctx.params.method}\",\"params\":\"\"}`,"method":"POST","mode":"cors"});
     ctx.assert((res.status === 200), res.status);
     const body = await res.json();
     ctx.body = body;


### PR DESCRIPTION
`/rpc/:method` will call the rpc method `method` from cbeam, e.g. `/rpc/events`.