### PR TITLE
Add matelight proxy

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ const routePictures = require('./route/pictures');
 const route35c3 = require('./route/35c3');
 const routeCalendar = require('./route/calendar');
 const routeCBeamRPC = require('./route/cbeamRpc');
+const routeMatelight = require('./route/matelight');
 
 const app = new Koa();
 const router = new Router();
@@ -17,6 +18,7 @@ route35c3(router);
 routePictures(router);
 routeCalendar(router);
 routeCBeamRPC(router);
+routeMatelight(router);
 
 app
   .use(Cors())

--- a/server/route/matelight.js
+++ b/server/route/matelight.js
@@ -1,0 +1,18 @@
+require('isomorphic-fetch');
+
+module.exports = (router) => {
+  router.get('/matelight/:command', async (ctx) => {
+    const { command } = ctx.params;
+    const res = await fetch(`http://matelight.cbrp3.c-base.org/api/${command}`);
+    ctx.assert((res.status === 200), res.status);
+    const body = await res.json();
+    ctx.body = body;
+  });
+  router.get('/matelight/:command/:argument', async (ctx) => {
+    const { command, argument } = ctx.params;
+    const res = await fetch(`http://matelight.cbrp3.c-base.org/api/${command}/${argument}`);
+    ctx.assert((res.status === 200), res.status);
+    const body = await res.json();
+    ctx.body = body;
+  });
+};

--- a/server/route/matelight.js
+++ b/server/route/matelight.js
@@ -1,14 +1,15 @@
 require('isomorphic-fetch');
 
 module.exports = (router) => {
-  router.get('/matelight/:command', async (ctx) => {
+  router.post('/matelight/:command', async (ctx) => {
     const { command } = ctx.params;
     const res = await fetch(`http://matelight.cbrp3.c-base.org/api/${command}`);
     ctx.assert((res.status === 200), res.status);
     const body = await res.json();
     ctx.body = body;
   });
-  router.get('/matelight/:command/:argument', async (ctx) => {
+  router.post('/matelight/:command/:argument', async (ctx) => {
+    console.log(ctx)
     const { command, argument } = ctx.params;
     const res = await fetch(`http://matelight.cbrp3.c-base.org/api/${command}/${argument}`);
     ctx.assert((res.status === 200), res.status);


### PR DESCRIPTION
`/matelight/:command` will call matelight's api `/api/{command}`.
`/matelight/:command/:argument` will call matelight's api `/api/{command}/{argument}`.

Examples:

`http://c-flo.cbrp3.c-base.org/matelight/getstatus` show the current playing video
`http://c-flo.cbrp3.c-base.org/matelight/play/fireplace` play the 'fireplace' video